### PR TITLE
sanders: mark camera daemon as API 27

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -121,7 +121,7 @@ BOARD_HAVE_BLUETOOTH_QCOM := true
 
 # Camera
 TARGET_PROCESS_SDK_VERSION_OVERRIDE := \
-    /system/vendor/bin/mm-qcamera-daemon=26
+    /system/vendor/bin/mm-qcamera-daemon=27
 USE_DEVICE_SPECIFIC_CAMERA := true
 TARGET_USES_NON_TREBLE_CAMERA := true
 BOARD_QTI_CAMERA_32BIT_ONLY := true


### PR DESCRIPTION
Our camera daemon comes from Oreo 8.1, not Oreo 8.0